### PR TITLE
Added contact seeding

### DIFF
--- a/model/pointcloud.py
+++ b/model/pointcloud.py
@@ -181,7 +181,7 @@ class CT(object):
     def select_points_near(self, point, nearby_range=10):
         self.select_points(self.all_points.get_points_in_range(point, nearby_range))
 
-    def select_weighted_center(self, point, radius=10, iterations=1):
+    def select_weighted_center(self, point, radius=4, iterations=1):
         self.select_points_near(point, radius)
         for _ in range(iterations):
             centered_point = self.selected_points.get_center()

--- a/view/pyloc_view.py
+++ b/view/pyloc_view.py
@@ -22,7 +22,6 @@ from slice_viewer import SliceViewWidget
 __author__ = 'iped'
 SEEDING = False
 LAST_CONTACT = np.array([0, 0, 0])
-SEED_CONTACT = 1
 
 
 class PyLocControl(object):
@@ -74,8 +73,7 @@ class PyLocControl(object):
             self.seed_points(centered_coordinate)
             
     def seed_points(self, centered_coordinate):
-        global SEED_CONTACT
-        print 'Contact #: ',SEED_CONTACT
+        print 'Contact #: ',self.get_grid_coordinates()[1]
         global LAST_CONTACT
         print 'Last contact: ',LAST_CONTACT
         print 'New contact: ',centered_coordinate
@@ -85,11 +83,14 @@ class PyLocControl(object):
             print 'Distance: ',dist
             if dist < 3 or dist > 15:
                 return
-            SEED_CONTACT+=1
+            self.add_selected_electrode()
+            if self.get_grid_coordinates()[1] > self.get_lead_dimensions()[1]:
+                return
             LAST_CONTACT = centered_coordinate
             self.select_coordinate(new_coordinate)
         else:
             LAST_CONTACT = centered_coordinate
+            self.add_selected_electrode()
 
     GRID_PRIORITY=1
 
@@ -118,7 +119,8 @@ class PyLocControl(object):
     def toggle_seeding(self):
         global SEEDING
         SEEDING = not SEEDING
-        print SEEDING
+        global LAST_CONTACT
+        LAST_CONTACT = np.array([0, 0, 0])
 
     def key_pressed(self, e):
         self.add_selected_electrode()
@@ -132,6 +134,10 @@ class PyLocControl(object):
     def get_grid_coordinates(self):
         return (int(self.view.submission_layout.coordinates_x_edit.text()),
                 int(self.view.submission_layout.coordinates_y_edit.text()))
+    
+    def get_lead_dimensions(self):
+        return (int(self.view.submission_layout.dimensions_x_edit.text()),
+                int(self.view.submission_layout.dimensions_y_edit.text()))
 
     def update_electrode_lead(self):
         self.view.submission_layout.contact_grid_label.setText(


### PR DESCRIPTION
Initial attempt at contact seeding. Works okay for depths, maybe strips.
Note I am new to github and relatively new to python.
I'm not really saying this has to be added but sharing my work.

Fixes:
- Adjusted radius for selected_weighted_center
- Removed default color and point masking from the initial point cloud plot

Additions:
- Added "Seed contacts" button to turn seeding on or off.
- User clicks on first contact then next contact, vector between the two gives subsequent contacts recursively and stops when no points are found or the coordinate is outside of distance range
- Prints out the contact coordinates and distances

To do:
- "Seed contacts" button should prompt user to enter electrode name and dimensions and to click on the first two contacts.
- Electrode dimensions should be used to stop the seeding or to move on to the next row of a grid, probably prompting the user to click the first contact of that next row.